### PR TITLE
Fixed organization name

### DIFF
--- a/core/serializers.py
+++ b/core/serializers.py
@@ -207,7 +207,7 @@ class CoreUserProfileSerializer(serializers.ModelSerializer):
 
 class CoreUserInvitationSerializer(serializers.Serializer):
     emails = serializers.ListField(child=serializers.EmailField(),
-                                   min_length=1, max_length=10)
+                                   min_length=1)
 
 
 class CoreUserEventInvitationSerializer(serializers.Serializer):
@@ -217,9 +217,11 @@ class CoreUserEventInvitationSerializer(serializers.Serializer):
     room_uuid = serializers.UUIDField()
     event_uuid = serializers.UUIDField()
     emails = serializers.ListField(child=serializers.CharField(),
-                                   min_length=1, max_length=10)
+                                   min_length=1)
     event_name = serializers.CharField()
     organization_name = serializers.CharField()
+    start_date_time = serializers.DateTimeField()
+    end_date_time = serializers.DateTimeField()
 
 
 class CoreUserResetPasswordSerializer(serializers.Serializer):

--- a/core/views/coreuser.py
+++ b/core/views/coreuser.py
@@ -23,7 +23,8 @@ from core.jwt_utils import create_invitation_token, create_invitation_token_even
 from core.email_utils import send_email
 
 from rest_framework.permissions import AllowAny
-from ics import Calendar, Event
+from ics import Calendar, Event, Organizer
+from buildly.settings.email import DEFAULT_FROM_EMAIL
 
 
 class CoreUserViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
@@ -308,7 +309,7 @@ class CoreUserViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
         e.begin = str(start_date_time)
         e.end = str(end_date_time)
         e.uid = event_uuid
-        e.organizer = str(organization_name)
+        e.organizer = Organizer(common_name=str(organization_name), email=DEFAULT_FROM_EMAIL)
         c.events.add(e)
 
         for email in emails:


### PR DESCRIPTION
Fixed Organization name not being sent in Calendar Invite. Also fixed the issue which was letting only 10 email invites to be sent at a time.