### PR TITLE
correct ics invite

### DIFF
--- a/core/email_utils.py
+++ b/core/email_utils.py
@@ -4,20 +4,21 @@ from django.conf import settings
 
 
 def send_email(email_address: str, subject: str, context: dict, template_name: str,
-               html_template_name: str = None,attachment=None) -> int:
+               html_template_name: str = None, attachment=None) -> int:
     text_content = loader.render_to_string(template_name, context, using=None)
     html_content = loader.render_to_string(html_template_name, context, using=None) if html_template_name else None
-    return send_email_body(email_address, subject, text_content, html_content,attachment)
+    return send_email_body(email_address, subject, text_content, html_content, attachment)
 
 
-def send_email_body(email_address: str, subject: str, text_content: str, html_content: str = None,attachment=None) -> int:
+def send_email_body(email_address: str, subject: str, text_content: str, html_content: str = None, attachment=None) -> int:
     msg = EmailMultiAlternatives(
         from_email=settings.DEFAULT_FROM_EMAIL,
         subject=subject,
         body=text_content,
         to=[email_address],
     )
-    msg.attach('invite.ics',attachment,'text/calendar')
+    if attachment:
+        msg.attach('invite.ics', attachment, 'text/calendar')
     if settings.DEFAULT_REPLYTO_EMAIL:
         msg.reply_to = [settings.DEFAULT_REPLYTO_EMAIL]
     if html_content:


### PR DESCRIPTION
## Purpose
ICS invite to be made optional in email send.

## Approach
Check if ics attachment is present then only send it, otherwise do not attach anything.
